### PR TITLE
fix to build aliases in the same step

### DIFF
--- a/.github/workflows/ocaml-general.yml
+++ b/.github/workflows/ocaml-general.yml
@@ -101,6 +101,7 @@ jobs:
     env:
       DOCKER_TAG: ${{ matrix.os }}-ocaml.${{ matrix.ocaml-version }}-node.${{ matrix.node-version }}-${{ matrix.arch }}
       CACHE_DIR: /tmp/docker-cache
+      PACKAGE_NAME: ghcr.io/kxcteam/ocaml-general
 
     if: github.event.pull_request.draft == false
 
@@ -110,7 +111,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up env var
-        run: echo "PACKAGE_INSTALL_SCRIPT_FILENAME=install_ocaml_$(eval cut -d'.' -f1 <<< ${{ matrix.ocaml-version }})_packages.sh" | tee -a $GITHUB_ENV
+        run: |
+          echo "PACKAGE_INSTALL_SCRIPT_FILENAME=install_ocaml_$(eval cut -d'.' -f1 <<< ${{ matrix.ocaml-version }})_packages.sh" | tee -a $GITHUB_ENV
+          echo "DOCKER_TAG_LIST=${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }},${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }}-${{ github.sha }}" | tee -a $GITHUB_ENV
+      
+      - name: Set up env var for alias (node hydrogen && arch amd64)
+        if: ${{ matrix.node-version == 'hydrogen' && matrix.arch == 'amd64' }}
+        run: echo "DOCKER_TAG_LIST=${{ env.DOCKER_TAG_LIST }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }}-${{ github.sha }}" | tee -a $GITHUB_ENV
 
       - name: Set up QEMU for arm64
         uses: docker/setup-qemu-action@v2
@@ -148,23 +155,9 @@ jobs:
             NODE_VERSION=${{ matrix.node-version }}
             OCAML_VERSION=${{ matrix.ocaml-version }}
             PACKAGE_INSTALL_SCRIPT_FILENAME=${{ env.PACKAGE_INSTALL_SCRIPT_FILENAME }}
-          tags: "ghcr.io/kxcteam/ocaml-general:${{ env.DOCKER_TAG }},ghcr.io/kxcteam/ocaml-general:${{ env.DOCKER_TAG }}-${{ github.sha }}"
+          tags: ${{ env.DOCKER_TAG_LIST }}
           cache-from: type=local,src=${{ env.CACHE_DIR }}/.buildx-cache
           cache-to: type=local,dest=${{ env.CACHE_DIR }}/.buildx-cache-new,mode=max
-
-      - name: Build and push image (OCaml ${{ matrix.ocaml-version }})
-        if: ${{ matrix.node-version == 'hydrogen' && matrix.arch == 'amd64' }}
-        uses: docker/build-push-action@v4
-        with:
-          context: ocaml-general
-          push: ${{ github.ref == 'refs/heads/main' }}
-          platforms: linux/${{ matrix.arch }}
-          build-args: |
-            NODE_VERSION=${{ matrix.node-version }}
-            OCAML_VERSION=${{ matrix.ocaml-version }}
-            PACKAGE_INSTALL_SCRIPT_FILENAME=${{ env.PACKAGE_INSTALL_SCRIPT_FILENAME }}
-          tags: "ghcr.io/kxcteam/ocaml-general:${{ matrix.ocaml-version }},ghcr.io/kxcteam/ocaml-general:${{ matrix.ocaml-version }}-${{ github.sha }}"
-          cache-from: type=local,src=${{ env.CACHE_DIR }}/.buildx-cache-new
 
       - name: Move cache
         run: |

--- a/.github/workflows/ocaml-general.yml
+++ b/.github/workflows/ocaml-general.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Set up env var
         run: |
           echo "PACKAGE_INSTALL_SCRIPT_FILENAME=install_ocaml_$(eval cut -d'.' -f1 <<< ${{ matrix.ocaml-version }})_packages.sh" | tee -a $GITHUB_ENV
-          echo "DOCKER_TAG_LIST=${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }},${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }}-${{ github.sha }}" | tee -a $GITHUB_ENV
+          echo "DOCKER_TAG_LIST=${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }},${{ env.PACKAGE_NAME }}:${{ env.DOCKER_TAG }}-${{ github.sha }}" | tee -a $GITHUB_ENV  | tr '=,' '\n' | sort
       
       - name: Set up env var for alias (node hydrogen && arch amd64)
         if: ${{ matrix.node-version == 'hydrogen' && matrix.arch == 'amd64' }}

--- a/.github/workflows/ocaml-general.yml
+++ b/.github/workflows/ocaml-general.yml
@@ -117,7 +117,7 @@ jobs:
       
       - name: Set up env var for alias (node hydrogen && arch amd64)
         if: ${{ matrix.node-version == 'hydrogen' && matrix.arch == 'amd64' }}
-        run: echo "DOCKER_TAG_LIST=${{ env.DOCKER_TAG_LIST }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }}-${{ github.sha }}" | tee -a $GITHUB_ENV
+        run: echo "DOCKER_TAG_LIST=${{ env.DOCKER_TAG_LIST }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }},${{ env.PACKAGE_NAME }}:${{ matrix.ocaml-version }}-${{ github.sha }}" | tee -a $GITHUB_ENV | tr '=,' '\n' | sort
 
       - name: Set up QEMU for arm64
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
When the Docker image for alias is built separately, it is displayed as a different image on ghcr and is difficult to understand.

 <img width="1011" alt="スクリーンショット 2023-02-23 0 31 31" src="https://user-images.githubusercontent.com/115773797/220677080-deb6b801-9306-4712-9b14-6b85a37c6ea3.png">

`4.13.1` is an alias for `ubuntu.22.04-ocaml.4.13.1-node.hydrogen-amd64`, however, they look like different images.