### PR TITLE
fix install_ocaml_5.4_packages.sh

### DIFF
--- a/.github/workflows/ocaml-general.yml
+++ b/.github/workflows/ocaml-general.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'ocaml-general/**'
       - '!ocaml-general/README.md'
+      - 'scripts/**'
       - '.github/workflows/ocaml-general.yml'
     branches: [main]
   workflow_dispatch:
@@ -20,6 +21,7 @@ on:
     paths:
       - 'ocaml-general/**'
       - '!ocaml-general/README.md'
+      - 'scripts/**'
       - '.github/workflows/ocaml-general.yml'
   merge_group:
 
@@ -70,6 +72,8 @@ jobs:
         with:
           context: ocaml-general
           push: false
+          load: true
+          tags: ocaml-general-test:${{ matrix.ocaml-version }}
           platforms: linux/${{ matrix.arch }}
           build-args: |
             NODE_VERSION=${{ matrix.node-version }}
@@ -77,6 +81,9 @@ jobs:
             PACKAGE_INSTALL_SCRIPT_FILENAME=${{ env.PACKAGE_INSTALL_SCRIPT_FILENAME }}
           cache-from: type=local,src=${{ env.CACHE_DIR }}/.buildx-cache
           cache-to: type=local,dest=${{ env.CACHE_DIR }}/.buildx-cache-new,mode=max
+
+      - name: Verify installed packages (${{ env.DOCKER_TAG }})
+        run: ./scripts/test_install_ocaml_docker.sh --image ocaml-general-test:${{ matrix.ocaml-version }} ${{ matrix.ocaml-version }}
 
       - name: Move cache
         run: |

--- a/docs/dev/ocaml-general.md
+++ b/docs/dev/ocaml-general.md
@@ -1,0 +1,68 @@
+# ocaml-general dev doc
+
+## Adding a new OCaml version
+
+### When no install script exists yet for the corresponding major version
+
+1. Add a new install script to the [ocaml-general/](../../ocaml-general/) directory.
+2. Run [scripts/check_install_ocaml.sh](../../scripts/check_install_ocaml.sh) with the OCaml version; the installation succeeds if there are no problems with the individual package versions.
+
+   ```console
+   $ ./scripts/check_install_ocaml.sh 5.4.1
+   ```
+
+   The script asks for confirmation (`[y/N]`) before proceeding; if the current
+   opam switch does not match the given version, it offers to create (or select)
+   the opam switch for that version first. Set `CHECK_INSTALL_OCAML_YES=1` to
+   answer the prompt automatically (for CI / non-interactive use).
+
+   > [!NOTE]
+   > Running an install script directly can appear to succeed overall even when
+   > an installation step fails along the way. The check script makes the whole
+   > run fail on any error, and additionally verifies that every package listed
+   > in `packages` is actually installed in the current switch.
+3. If it fails, search for the affected packages on [opam](https://opam.ocaml.org/packages/) and update them to versions that are mutually consistent.
+
+### When updating package versions in an existing install script
+
+Verify with the check script in the same way; it offers to create/select the
+opam switch for the target version if needed.
+
+```console
+$ ./scripts/check_install_ocaml.sh 5.4.1
+```
+
+### Verifying inside a Docker container
+
+To verify without touching any local opam switch, use
+[scripts/test_install_ocaml_docker.sh](../../scripts/test_install_ocaml_docker.sh).
+It builds [ocaml-general/Dockerfile](../../ocaml-general/Dockerfile) for the target
+version, and then runs
+[check_install_ocaml.sh](../../scripts/check_install_ocaml.sh) inside the container
+to verify that every package is installed at the specified version. Note that a
+failed `opam install` does not fail the docker build itself, so this in-container
+verification is what actually catches installation failures.
+
+```console
+$ ./scripts/test_install_ocaml_docker.sh 5.4.1
+
+# to pass extra arguments to docker build
+$ ./scripts/test_install_ocaml_docker.sh 5.4.1 -- --no-cache --build-arg NODE_VERSION=krypton
+
+# to only verify a pre-built image (used in CI)
+$ ./scripts/test_install_ocaml_docker.sh --image ocaml-general-test:5.4.1 5.4.1
+```
+
+> [!NOTE]
+> The first run takes a while since it builds the entire image, including the
+> OCaml compiler. Subsequent runs only re-execute the changed parts of the
+> install script thanks to Docker layer caching. If newly published package
+> versions are not found, the `opam update` layer is still cached, so re-run
+> with `-- --no-cache`.
+
+CI (the `validate-ocaml-general` job in [ocaml-general.yml](../../.github/workflows/ocaml-general.yml))
+also automatically runs this verification in `--image` mode against the built image.
+
+### Updating .github/workflows/ocaml-general.yml
+
+Specify the OCaml version in [ocaml-general.yml](../../.github/workflows/ocaml-general.yml).

--- a/ocaml-general/install_ocaml_5.4_packages.sh
+++ b/ocaml-general/install_ocaml_5.4_packages.sh
@@ -1,28 +1,27 @@
 #!/bin/bash -xe
 
 packages=(
-  dune.3.18.2
-  dune-build-info.3.17.2
+  dune.3.19.1
+  dune-build-info.3.19.1
   merlin
   odoc.3.1.0
   ppxlib.0.37.0
-  bisect_ppx.2.8.3
   ppx_deriving.6.1.1
-  js_of_ocaml.6.0.1 js_of_ocaml-ppx.6.0.1 js_of_ocaml-lwt.6.0.1
+  js_of_ocaml.6.1.0 js_of_ocaml-ppx.6.1.0 js_of_ocaml-lwt.6.1.0
   jsonm.1.0.2
   ezjsonm.1.3.0
   ppx_optcomp.v0.17.1
   brr.0.0.7
   prr.0.1.1
   zed.3.2.3
-  ppx_inline_test.v0.17.0
+  ppx_inline_test.v0.17.1
   alcotest.1.8.0
   qcheck.0.24
   qcheck-alcotest.0.24
-  sexplib.v0.17.0 ppx_sexp_conv.v0.17.0
-  yojson.2.2.2 ppx_yojson_conv.v0.17.0
+  sexplib.v0.17.0 ppx_sexp_conv.v0.17.1
+  yojson.2.2.2 ppx_yojson_conv.v0.17.1
   tezt.4.2.0
-  melange.5.0.1-54
+  melange.6.0.1-54
   uuidm.0.9.9
   bigstringaf.0.10.0
   angstrom.0.16.1
@@ -30,15 +29,15 @@ packages=(
 )
 
 pins=(
-  dune 3.18.2
-  dune-action-plugin 3.17.2
-  dune-build-info 3.17.2
-  dune-configurator 3.17.2
-  dune-glob 3.17.2
-  dune-private-libs 3.17.2
-  dune-rpc 3.17.2
-  dune-rpc-lwt 3.17.2
-  dune-site 3.17.2
+  dune 3.19.1
+  dune-action-plugin 3.19.1
+  dune-build-info 3.19.1
+  dune-configurator 3.19.1
+  dune-glob 3.19.1
+  dune-private-libs 3.19.1
+  dune-rpc 3.19.1
+  dune-rpc-lwt 3.19.1
+  dune-site 3.19.1
 )
 
 echo "${pins[@]}" | xargs -n 2 opam pin -n add

--- a/ocaml-general/install_ocaml_5.4_packages.sh
+++ b/ocaml-general/install_ocaml_5.4_packages.sh
@@ -22,7 +22,7 @@ packages=(
   yojson.2.2.2 ppx_yojson_conv.v0.17.1
   tezt.4.2.0
   melange.6.0.1-54
-  uuidm.0.9.9
+  uuidm.0.9.10
   bigstringaf.0.10.0
   angstrom.0.16.1
   uri.4.4.0

--- a/scripts/check_install_ocaml.sh
+++ b/scripts/check_install_ocaml.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+## Runs the ocaml-general package install script for the given OCaml version
+## with strict error checking, then verifies that every package listed in the
+## script is actually installed in the current opam switch.
+##
+## If the current opam switch does not match the given version, offers to
+## create (or select) the opam switch for that version first.
+##
+## The install scripts themselves can appear to succeed even when `opam
+## install` fails: the failure happens inside an `... && opam clean` list,
+## which `set -e` does not abort on. This script therefore verifies the
+## installed packages after the run instead of trusting the exit status.
+##
+## usage:
+##   ./scripts/check_install_ocaml.sh <ocaml-version>
+## examples:
+##   ./scripts/check_install_ocaml.sh 5.4.1
+##   ./scripts/check_install_ocaml.sh 4.14.2
+##
+## environment:
+##   CHECK_INSTALL_OCAML_YES=1   answer "y" to the confirmation prompt
+##                               automatically (for CI / non-interactive use)
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+usage() {
+  grep '^##' "$0" | sed 's/^## \{0,1\}//' >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+version=$1
+
+# derive the install script path from the major.minor part of the version
+script_version=$(echo "$version" | cut -d'.' -f1-2)
+install_script="$repo_root/ocaml-general/install_ocaml_${script_version}_packages.sh"
+
+if [[ ! -f $install_script ]]; then
+  echo "error: install script not found: $install_script" >&2
+  usage
+  exit 2
+fi
+
+# decide whether the opam switch for the given version needs to be set up
+switch_ocaml=$(opam exec -- ocamlc -vnum 2>/dev/null || true)
+
+if [[ -n $switch_ocaml && ${switch_ocaml%.*} == "$script_version" ]]; then
+  target_switch=""
+  prompt="install the packages of $(basename "$install_script") into the current opam switch '$(opam switch show)' (OCaml $switch_ocaml)?"
+else
+  target_switch=$version
+  prompt="create/select opam switch '$version' and install the packages of $(basename "$install_script") into it?"
+fi
+
+# [y/N] gate; CHECK_INSTALL_OCAML_YES=1 (or y/yes) skips the prompt (for CI)
+if [[ ${CHECK_INSTALL_OCAML_YES:-} =~ ^([1yY]|[yY][eE][sS])$ ]]; then
+  echo "==> proceeding without prompt (CHECK_INSTALL_OCAML_YES=${CHECK_INSTALL_OCAML_YES})"
+else
+  read -r -p "==> ${prompt} [y/N] " answer || answer=""
+  if [[ ! $answer =~ ^([yY]|[yY][eE][sS])$ ]]; then
+    echo "aborted" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n $target_switch ]]; then
+  if opam switch list --short 2>/dev/null | grep -qxF "$target_switch"; then
+    echo "==> selecting existing opam switch $target_switch"
+    opam switch set "$target_switch"
+  else
+    echo "==> creating opam switch $target_switch"
+    opam switch create "$target_switch"
+  fi
+  switch_ocaml=$(opam exec -- ocamlc -vnum)
+fi
+
+echo "==> current opam switch: $(opam switch show) (OCaml $switch_ocaml)"
+echo "==> running $install_script"
+bash -ex -o pipefail "$install_script"
+
+# extract the `packages=( ... )` array literal from the install script
+packages=()
+eval "$(sed -n '/^packages=(/,/^)/p' "$install_script")"
+
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "error: could not extract the packages list from $install_script" >&2
+  exit 2
+fi
+
+echo "==> verifying that ${#packages[@]} packages are installed"
+installed=$(opam list --installed --columns=package --short)
+
+result=0
+for pkg in "${packages[@]}"; do
+  if [[ $pkg == *.* ]]; then
+    # name.version: require the exact version to be installed
+    found=$(grep -cxF "$pkg" <<<"$installed") || true
+  else
+    # bare name: any installed version is fine
+    found=$(cut -d'.' -f1 <<<"$installed" | grep -cxF "$pkg") || true
+  fi
+  if [[ $found -eq 0 ]]; then
+    actual=$(awk -F'.' -v n="${pkg%%.*}" '$1 == n' <<<"$installed")
+    echo "NOT INSTALLED: $pkg (installed: ${actual:-none})" >&2
+    result=1
+  fi
+done
+
+if [[ $result -ne 0 ]]; then
+  echo "==> FAILED: some packages are missing from the current switch" >&2
+  exit 1
+fi
+echo "==> OK: all packages are installed"

--- a/scripts/test_install_ocaml_docker.sh
+++ b/scripts/test_install_ocaml_docker.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+## Builds the ocaml-general Docker image for the given OCaml version and runs
+## scripts/check_install_ocaml.sh inside the resulting container, so that the
+## package install scripts can be tested without touching any local opam
+## switch. Usable both locally and in CI.
+##
+## usage:
+##   ./scripts/test_install_ocaml_docker.sh [--image <image>] <ocaml-version> [-- <extra docker build args>]
+##
+## examples:
+##   # build the image locally and verify the package installation
+##   ./scripts/test_install_ocaml_docker.sh 5.4.1
+##
+##   # pass extra args to docker build
+##   ./scripts/test_install_ocaml_docker.sh 5.4.1 -- --no-cache --build-arg NODE_VERSION=krypton
+##
+##   # verify a pre-built image without building it (e.g. in CI)
+##   ./scripts/test_install_ocaml_docker.sh --image ocaml-general-test:5.4.1 5.4.1
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+usage() {
+  grep '^##' "$0" | sed 's/^## \{0,1\}//' >&2
+}
+
+image=""
+version=""
+build_args=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --image)
+      if [[ $# -lt 2 ]]; then usage; exit 2; fi
+      image=$2
+      shift 2 ;;
+    --)
+      shift
+      build_args=("$@")
+      break ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 2 ;;
+    *)
+      if [[ -n $version ]]; then
+        echo "error: multiple versions given: $version, $1" >&2
+        usage
+        exit 2
+      fi
+      version=$1
+      shift ;;
+  esac
+done
+
+if [[ -z $version ]]; then
+  usage
+  exit 2
+fi
+
+script_version=$(echo "$version" | cut -d'.' -f1-2)
+install_script_filename="install_ocaml_${script_version}_packages.sh"
+if [[ ! -f "$repo_root/ocaml-general/$install_script_filename" ]]; then
+  echo "error: install script not found: ocaml-general/$install_script_filename" >&2
+  exit 2
+fi
+
+if [[ -z $image ]]; then
+  image="ocaml-general-test:$version"
+  echo "==> building $image (OCAML_VERSION=$version)"
+  # NB: a failed `opam install` does not fail this build (the install scripts
+  # swallow it); the docker run below is what validates the installation
+  docker build \
+    --build-arg OCAML_VERSION="$version" \
+    --build-arg PACKAGE_INSTALL_SCRIPT_FILENAME="$install_script_filename" \
+    ${build_args[@]+"${build_args[@]}"} \
+    --tag "$image" \
+    "$repo_root/ocaml-general"
+else
+  echo "==> using existing image: $image (skipping docker build)"
+fi
+
+# verify inside the container that every listed package is actually installed
+echo "==> running check_install_ocaml.sh inside $image"
+docker run --rm \
+  --volume "$repo_root:/repo:ro" \
+  --env CHECK_INSTALL_OCAML_YES=1 \
+  "$image" \
+  bash /repo/scripts/check_install_ocaml.sh "$version"
+
+echo "==> OK: docker install test passed for OCaml $version"


### PR DESCRIPTION
CIが通ったら問題ないと思っていたのですが、特にCIでは何もチェックしていなさそうだったため、手元でインストールスクリプト実行したら色々エラー出たので修正しました。

`bisect_ppx` 最新でこれなので一旦消します。
bisect_ppx >= 2.8.3 → ppxlib < 0.36.0 → ocaml-migrate-parsetree >= 1.3.1 → ocaml < 4.10 